### PR TITLE
add hyper run -v volume initilisation reference

### DIFF
--- a/Feature/volume.md
+++ b/Feature/volume.md
@@ -21,6 +21,14 @@ You can also create volumes with `run`:
 
     $ hyper run -v /opt/data/ --name mycontainer ubuntu         // a 10GB volume will be created
     mycontainer
+    $ hyper run -v /localdata/:/opt/data --name mycontainer ubuntu   // a 10GB volume will be created and filled with contents in /localdata directory
+    mycontainer
+    $ hyper run -v git://url:branch:/opt/data --name mycontainer ubuntu   // a 10GB volume will be created and filled with contents cloned from git://url:branch
+    mycontainer                                                           // and branch is optional in the git url
+    $ hyper run -v http://url.git:/opt/data --name mycontainer ubuntu // a 10GB volume will be created and filled with contents cloned from http://url.git
+    mycontainer                                                       // branch name is also supported like in the above case
+    $ hyper run -v http://url:/opt/data --name mycontainer ubuntu    // a 10GB volume will be created and filled with contents fetched from http://url
+    mycontainer
     
 Once a volume is attached to a container, it will be associated with the container throughout the container's lifecycle, which means that when you (re)start the container, you don't need to mount the volume again. The only exception is that if you mount the volume of a stopped container to another container, the stopped container cannot be started.
 

--- a/Reference/CLI/run.md
+++ b/Reference/CLI/run.md
@@ -46,6 +46,25 @@ The `-w` lets the command being executed inside directory given, here
 
 The mount is created inside the container's `/world` directory. Hyper_ does not support relative paths for mount points inside the container.
 
+#### Initialize volume (-v)
+Volume initialization via `hyper run -v` will acquire additional resources (volume, container and possibly fip) to accomplish initialization. So be aware of the addtional cost that might occur.
+
+    $ hyper run -d -v /localdir:/remotedir busybox ls /remotedir
+
+A new volume is created and filled with contents from /localdir directory, and then mounted to /remotedir inside the container.
+
+    $ hyper run -d -v git://url:branch:/data busybox ls /data
+
+A new volume is created and filled with contents cloned from git://url:branch, and then mounted to /data inside the container. The branch name in the git url is optional.
+
+    $ hyper run -d -v http://url.git:branch:/data busybox ls /data
+
+A new volume is created and filled with contents cloned from http://url.git:branch, and then mounted to /data inside the container. The Branch name in the git url is optinal.
+
+    $ hyper run -d -v http://url:/data busybox ls /data
+
+A new volume is created with contents fetched from http://url and then mounted to /data inside the container.
+
 #### Set environment variables (-e, --env, --env-file)
 
     $ hyper run -e MYVAR1 --env MYVAR2=foo --env-file ./env.list ubuntu bash


### PR DESCRIPTION
The PR adds document for `hyper run -v` volume initialization supported added by https://github.com/hyperhq/hypercli/pull/117 and https://github.com/hyperhq/hypercli/pull/119. Note those PRs are still under review.