### PR TITLE
Improve wording on FIP

### DIFF
--- a/Feature/fip.md
+++ b/Feature/fip.md
@@ -1,24 +1,38 @@
-# Floaing IP
+# Floating IP
 
-A floating IP is a publicly-accessible IP address that can be assigned to one container. Floating IPs can be remapped to other containers in the same region, to mask the failure of container or application. 
+A floating IP or also called FIP, is a public accessible IP address that can be associated to one container. A Floating IP can also be remapped to other containers in the same region, and can be used this way to switch between different deployments.
 
 You need to allocate new free IPs before assigning them to containers:
 
-    $ hyper fip allocate 4
+    $ hyper fip allocate 1
     52.68.129.19
-    52.68.129.20
-    52.68.129.21
-    52.68.129.22
     $ hyper fip associate 52.68.129.19 myweb
     myweb
 
-To de-associate a floating IP from a container:
+To remove a floating IP from a container you disassociate it:
 
     $ hyper fip disassociate myweb
     52.68.129.19
-    
+
+If you want to move the floating ip from one container to another, you must first disassociate it from the old container and then associate it again like this:
+
+    $ hyper fip disassociate myweb && hyper fip associate 52.68.129.19 myweb2
+
+## Deleting Floating IP's
+
+When you `rm` a container, the floating IP will be automatically disassociated.
+
+You can also release the ip if there is no container associate:
+
+    $ hyper fip release 52.68.129.19
+    52.68.129.19
+
+> NOTE: floating IP is priced at a monthly rate. When an IP is allocated, you will be charged for that current month.
+
+## Floating IP's when stopping and restarting containers
+
 When a container is stopped or restarted, the floating IP (if any) is still associated with the container, which means that when you (re)start the container, you don't need to associate the floating IP again.
-    
+
     $ hyper stop myweb
     myweb
     $ hyper ps -a
@@ -29,12 +43,3 @@ When a container is stopped or restarted, the floating IP (if any) is still asso
     $ hyper ps -a
     CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                      PORTS                      NAMES               PUBLIC IP
 	3259d441edae        ghost               "/entrypoint.sh npm s"   17 minutes ago      Up 4 seconds                0.0.0.0:2368->2368/tcp     myweb        		23.236.114.91
-
-However, when you `rm` a container, the floating IP will be automatically de-associated.
-
-To release a floating IP:
-
-    $ hyper fip release 52.68.129.19
-    52.68.129.19
-
-> NOTE: floating IP is priced at a monthly rate. When an IP is allocated, you will be charged for that current month.


### PR DESCRIPTION
- Fix spelling mistake in the headline
- Line 3: Remember to use the acronym that is used in the cli
- Line 3: Use associate instead of assign, because the wording "assigned" is never used anywhere else.
- Line 3: Remove **mask the failure** as you can't actually do that, without some heavy user monitoring. You could get the idea that Hyper has it built in!
- Line 7: I think it is seldom if every you need 4 ip's at one time, especially because the cost money.
- Line 12: Use the normal word "remove" and then use the actual word used in the cli **disassociate** and not de-associate.
Line 17-19: Create a section on how to actual move the ip.
- Line 21: Make it clear that release means remove. Put it before the stop-restarted example as it is more important!