### PR TITLE
Improve wording in networking

### DIFF
--- a/Feature/network.md
+++ b/Feature/network.md
@@ -1,7 +1,11 @@
 # Network
 
-By default, Hyper\_ setup a Layer-2 virtual private network for every user. All containers of a user will be automatically placed in the user's own network. Containers in the same network are reachable to each other, but isolated from other networks. Also, containers are able to access the Internet, but not accessible from Internet (To enable the public access, you can associate [floating IP](./fip.md) to container).
+Networking is easy with Hyper\_. All containers of a user will be automatically placed in the user's own network. Containers in the same network are reachable to each other, but isolated from other networks. In technical terms, Hyper\_ setup a Layer-2 virtual private network for every user.
 
-The [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) of the default private network is set to `172.16.0.0/16`. Note: Hyper\_ reserves a few addresses for its own usage. When a new container is launched, Hyper\_ will automatically assign a private IP address to the container. Currently, there is no way to control the IP allocation.
+Containers are able to access the Internet, but can not be acceessed by the public. This makes your containers more secure as you can't accidently expose an important part of your infrastructure to the public. (To enable the public access, you have to use a [floating IP](./fip.md) pointed to the container).
 
+## Default network configuration
 
+When a new container is launched, Hyper\_ will automatically assign a private IP address to the container. There is currently no way to control the IP allocation.
+
+The [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) of the default private network is set to `172.16.0.0/16`. Note: Hyper\_ reserves a few addresses for its own usage.


### PR DESCRIPTION
I was already lost when I read the first line on networking. It is not important which kind of network Hyper_ creates for the user, just that it works.

Line 3: They should that it is easy!
Line 5: Move down CIDR and move up how containers can access the public
Line 5: Use the word public more, as people know more clearly the difference public and private internet.
Line 7: Put a headline displaying the something more technical is coming up