### PR TITLE
Make volume description match implementation

### DIFF
--- a/Feature/volume.md
+++ b/Feature/volume.md
@@ -30,7 +30,7 @@ You can also create volumes with `run`:
     $ hyper run -v http://url:/container/path --name mycontainer ubuntu    				// a 10GB volume will be created and populated with data from from http://url
     mycontainer
     
-Once a volume is attached to a container, it will be associated with the container throughout the container's lifecycle, which means that when you (re)start the container, you don't need to mount the volume again. The only exception is that if you mount the volume of a stopped container to another container, the stopped container cannot be started.
+Once a volume is attached to a container, it will be associated with the container throughout the container's lifecycle, which means that when you (re)start the container, you don't need to mount the volume again. And it cannot be attached to a different container unless the first attaching container is removed.
 
 However, when you `rm` a container, the attached volumes will be automatically unmounted. To remove the attached volumes along with a container:
 

--- a/Feature/volume.md
+++ b/Feature/volume.md
@@ -32,7 +32,7 @@ You can also create volumes with `run`:
     
 Once a volume is attached to a container, it will be associated with the container throughout the container's lifecycle, which means that when you (re)start the container, you don't need to mount the volume again. And it cannot be attached to a different container unless the first attaching container is removed.
 
-However, when you `rm` a container, the attached volumes will be automatically unmounted. To remove the attached volumes along with a container:
+However, when you `rm` a container, the attached volumes will be automatically unmounted. To remove the auto-created volumes along with a container:
 
     $ hyper rm -v db_container
     db_container

--- a/Reference/CLI/rm.md
+++ b/Reference/CLI/rm.md
@@ -6,7 +6,7 @@
 
       -f, --force=false      Force the removal of a running container (uses SIGKILL)
       --help=false           Print usage
-      -v, --volumes=false    Remove the volumes associated with the container
+      -v, --volumes=false    Remove auto-created volumes associated with the container
 
 ### Examples
 


### PR DESCRIPTION
1. a volume cannot be attached to multiple containers, even if some/all of them are stopped.
2. `hyper rm -v` can only remove auto-created volumes, which means volumes created by `hyper volume create` will not be removed with `hyper rm -v`.

It's debatable if we should choose to implement otherwise, but let's fix the docs first.