### PR TITLE
Add missing link to commit command

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -18,6 +18,7 @@
 * [Reference](Reference/index.md)
    * [CLI](Reference/CLI/index.md)
        * [attach](Reference/CLI/attach.md)
+       * [commit](Reference/CLI/commit.md)
        * [config](Reference/CLI/config.md)
        * [create](Reference/CLI/create.md)
        * [exec](Reference/CLI/exec.md)


### PR DESCRIPTION
It was missing and the only reference was on the "run" page.